### PR TITLE
Change jQuery close mobile nav function.

### DIFF
--- a/js/scrolling-nav.js
+++ b/js/scrolling-nav.js
@@ -1,10 +1,6 @@
 //jQuery to collapse the navbar on scroll
 $(window).scroll(function() {
-    if ($(".navbar").offset().top > 50) {
-        $(".navbar-fixed-top").addClass("top-nav-collapse");
-    } else {
-        $(".navbar-fixed-top").removeClass("top-nav-collapse");
-    }
+    $(".navbar-ex1-collapse").removeClass("in");
 });
 
 //jQuery for page scrolling feature - requires jQuery Easing plugin


### PR DESCRIPTION
Changed $(".navbar-fixed-top").addClass("top-nav-collapse"); to $(".navbar-ex1-collapse").removeClass("in"); removed if else statement.

I found that it wasn't working on chrome an safari for IOS.
